### PR TITLE
Add support for shouldEnableFirstOtherButton delegate handling

### DIFF
--- a/Sources/CCAlertView.h
+++ b/Sources/CCAlertView.h
@@ -5,8 +5,10 @@ extern NSString *const CCAlertViewAnimatedKey;
 
 @property(nonatomic, assign) UIAlertViewStyle alertViewStyle;
 @property(copy) dispatch_block_t dismissAction;
+@property (copy, nonatomic) BOOL (^shouldEnableFirstOtherButtonBlock) (void);
 
 - (id) initWithTitle: (NSString*) title message: (NSString*) message;
+- (id) initWithTitle: (NSString*) title message: (NSString*) message cancelButtonTitle:(NSString*)cancelButtonTitle cancelButtonBlock:(dispatch_block_t)cancelButtonBlock firstOtherButtonTitle:(NSString*)firstOtherButtonTitle firstOtherButtonBlock:(dispatch_block_t)firstOtherButtonBlock;
 - (void) addButtonWithTitle: (NSString*) title block: (dispatch_block_t) block;
 
 - (void) show;

--- a/Sources/CCAlertView.m
+++ b/Sources/CCAlertView.m
@@ -21,6 +21,17 @@ NSString *const CCAlertViewAnimatedKey = @"CCAlertViewAnimated";
     return self;
 }
 
+- (id) initWithTitle: (NSString*) title message: (NSString*) message cancelButtonTitle:(NSString*)cancelButtonTitle cancelButtonBlock:(dispatch_block_t)cancelButtonBlock firstOtherButtonTitle:(NSString*)firstOtherButtonTitle firstOtherButtonBlock:(dispatch_block_t)firstOtherButtonBlock
+{
+    self = [super init];
+    alert = [[UIAlertView alloc] initWithTitle:title message:message
+                                      delegate:self cancelButtonTitle:cancelButtonTitle otherButtonTitles:firstOtherButtonTitle, nil];
+    if (!cancelButtonBlock) cancelButtonBlock = ^{};
+    if (!firstOtherButtonBlock) firstOtherButtonBlock = ^{};
+    blocks = [[NSMutableArray alloc] initWithObjects:[cancelButtonBlock copy], [firstOtherButtonBlock copy], nil];
+    return self;
+}
+
 - (void) show
 {
     [alert show];
@@ -75,6 +86,18 @@ NSString *const CCAlertViewAnimatedKey = @"CCAlertViewAnimated";
 {
     if ([alert respondsToSelector:@selector(alertViewStyle)]) {
         [alert setAlertViewStyle:alertViewStyle];
+    }
+}
+
+- (BOOL)alertViewShouldEnableFirstOtherButton:(UIAlertView *)alertView
+{
+    if (self.shouldEnableFirstOtherButtonBlock)
+    {
+        return self.shouldEnableFirstOtherButtonBlock();
+    }
+    else
+    {
+        return YES;
     }
 }
 


### PR DESCRIPTION
This involves providing a block so the user can respond to the delegate method, and an (admittedly ugly but necessary) additional init method. The extra init method is needed because if you don't provide an "other button" in UIAlertView init, it will never call alertViewShouldEnableFirstOtherButton, even if you add other buttons later.
